### PR TITLE
add KBUILD_EXTRA_SYMBOLS to Makefile of UseExport and UseFramework mo…

### DIFF
--- a/15-ExportSymbol/UseExport/Makefile
+++ b/15-ExportSymbol/UseExport/Makefile
@@ -2,6 +2,8 @@ PPROJ=example
 PROJ=useexample
 obj-m := $(PROJ).o
 
+KBUILD_EXTRA_SYMBOLS := $(PWD)/../Export/Module.symvers
+
 ifeq ($(KERNELDIR),)
 KERNELDIR=/lib/modules/$(shell uname -r)/build
 endif

--- a/16-Framework/UseFramework/Makefile
+++ b/16-Framework/UseFramework/Makefile
@@ -2,6 +2,8 @@ PPROJ=example
 PROJ=useexample
 obj-m := $(PROJ).o
 
+KBUILD_EXTRA_SYMBOLS := $(PWD)/../Framework/Module.symvers
+
 ifeq ($(KERNELDIR),)
 KERNELDIR=/lib/modules/$(shell uname -r)/build
 endif


### PR DESCRIPTION
**two Makefile were modified** 
  - 15-ExportSymbol/UseExport/Makefile
  - 16-Framework/UseFramework/Makefile

**added the path of module.symvers as below**
  _KBUILD_EXTRA_SYMBOLS := ........../Module.symvers_

[reference](https://stackoverflow.com/questions/16360689/invalid-parameters-error-when-trying-to-insert-module-that-accesses-exported-s)

Nice practice btw
I've learned a lot from it